### PR TITLE
fix: file resolving if exists directory with the same name

### DIFF
--- a/src/__snapshots__/index.spec.ts.snap
+++ b/src/__snapshots__/index.spec.ts.snap
@@ -367,6 +367,12 @@ exports[`file resolving mainFiles property: lstatSync 1`] = `
     },
   ],
   [
+    "/1.js",
+    {
+      "throwIfNoEntry": false,
+    },
+  ],
+  [
     "/1/package.json",
     {
       "throwIfNoEntry": false,
@@ -403,6 +409,12 @@ exports[`file resolving mainFiles property: lstatSync 1`] = `
     },
   ],
   [
+    "/2.js",
+    {
+      "throwIfNoEntry": false,
+    },
+  ],
+  [
     "/2/package.json",
     {
       "throwIfNoEntry": false,
@@ -422,6 +434,12 @@ exports[`file resolving mainFiles property: lstatSync 1`] = `
   ],
   [
     "/3",
+    {
+      "throwIfNoEntry": false,
+    },
+  ],
+  [
+    "/3.js",
     {
       "throwIfNoEntry": false,
     },
@@ -466,6 +484,12 @@ exports[`file resolving mainFiles property: realpathSync 1`] = `[]`;
 exports[`file resolving mainFiles property: statSync 1`] = `
 [
   [
+    "/1.js",
+    {
+      "throwIfNoEntry": false,
+    },
+  ],
+  [
     "/1/package.json",
     {
       "throwIfNoEntry": false,
@@ -490,6 +514,12 @@ exports[`file resolving mainFiles property: statSync 1`] = `
     },
   ],
   [
+    "/2.js",
+    {
+      "throwIfNoEntry": false,
+    },
+  ],
+  [
     "/2/package.json",
     {
       "throwIfNoEntry": false,
@@ -497,6 +527,12 @@ exports[`file resolving mainFiles property: statSync 1`] = `
   ],
   [
     "/2/index.custom",
+    {
+      "throwIfNoEntry": false,
+    },
+  ],
+  [
+    "/3.js",
     {
       "throwIfNoEntry": false,
     },
@@ -1945,6 +1981,12 @@ exports[`packages modules resolving package.json mainFields property: lstatSync 
     },
   ],
   [
+    "/node_modules/1.js",
+    {
+      "throwIfNoEntry": false,
+    },
+  ],
+  [
     "/node_modules/1/package.json",
     {
       "throwIfNoEntry": false,
@@ -1975,6 +2017,12 @@ exports[`packages modules resolving package.json mainFields property: lstatSync 
     },
   ],
   [
+    "/node_modules/2.js",
+    {
+      "throwIfNoEntry": false,
+    },
+  ],
+  [
     "/node_modules/2/package.json",
     {
       "throwIfNoEntry": false,
@@ -1988,6 +2036,12 @@ exports[`packages modules resolving package.json mainFields property: lstatSync 
   ],
   [
     "/node_modules/3",
+    {
+      "throwIfNoEntry": false,
+    },
+  ],
+  [
+    "/node_modules/3.js",
     {
       "throwIfNoEntry": false,
     },
@@ -2017,6 +2071,12 @@ exports[`packages modules resolving package.json mainFields property: lstatSync 
     },
   ],
   [
+    "/node_modules/4.js",
+    {
+      "throwIfNoEntry": false,
+    },
+  ],
+  [
     "/node_modules/4/package.json",
     {
       "throwIfNoEntry": false,
@@ -2036,6 +2096,12 @@ exports[`packages modules resolving package.json mainFields property: lstatSync 
   ],
   [
     "/node_modules/5",
+    {
+      "throwIfNoEntry": false,
+    },
+  ],
+  [
+    "/node_modules/5.js",
     {
       "throwIfNoEntry": false,
     },
@@ -2083,13 +2149,37 @@ exports[`packages modules resolving package.json mainFields property: realpathSy
 exports[`packages modules resolving package.json mainFields property: statSync 1`] = `
 [
   [
+    "/node_modules/1.js",
+    {
+      "throwIfNoEntry": false,
+    },
+  ],
+  [
     "/node_modules/1/baz",
     {
       "throwIfNoEntry": false,
     },
   ],
   [
+    "/node_modules/2.js",
+    {
+      "throwIfNoEntry": false,
+    },
+  ],
+  [
+    "/node_modules/3.js",
+    {
+      "throwIfNoEntry": false,
+    },
+  ],
+  [
     "/node_modules/3/index",
+    {
+      "throwIfNoEntry": false,
+    },
+  ],
+  [
+    "/node_modules/4.js",
     {
       "throwIfNoEntry": false,
     },
@@ -2102,6 +2192,12 @@ exports[`packages modules resolving package.json mainFields property: statSync 1
   ],
   [
     "/node_modules/4/index",
+    {
+      "throwIfNoEntry": false,
+    },
+  ],
+  [
+    "/node_modules/5.js",
     {
       "throwIfNoEntry": false,
     },
@@ -2148,6 +2244,12 @@ exports[`packages modules resolving package.json packageJSONModifier property: l
     },
   ],
   [
+    "/node_modules/1.js",
+    {
+      "throwIfNoEntry": false,
+    },
+  ],
+  [
     "/node_modules/1/package.json",
     {
       "throwIfNoEntry": false,
@@ -2172,6 +2274,12 @@ exports[`packages modules resolving package.json packageJSONModifier property: l
     },
   ],
   [
+    "/node_modules/2.js",
+    {
+      "throwIfNoEntry": false,
+    },
+  ],
+  [
     "/node_modules/2/package.json",
     {
       "throwIfNoEntry": false,
@@ -2185,6 +2293,12 @@ exports[`packages modules resolving package.json packageJSONModifier property: l
   ],
   [
     "/node_modules/3",
+    {
+      "throwIfNoEntry": false,
+    },
+  ],
+  [
+    "/node_modules/3.js",
     {
       "throwIfNoEntry": false,
     },
@@ -2226,7 +2340,25 @@ exports[`packages modules resolving package.json packageJSONModifier property: r
 exports[`packages modules resolving package.json packageJSONModifier property: statSync 1`] = `
 [
   [
+    "/node_modules/1.js",
+    {
+      "throwIfNoEntry": false,
+    },
+  ],
+  [
     "/node_modules/1/foo",
+    {
+      "throwIfNoEntry": false,
+    },
+  ],
+  [
+    "/node_modules/2.js",
+    {
+      "throwIfNoEntry": false,
+    },
+  ],
+  [
+    "/node_modules/3.js",
     {
       "throwIfNoEntry": false,
     },

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -216,8 +216,8 @@ export default class SyncResolver {
   private tryToResolveFile(absPath: string): string | null {
     let realpath = this.realpath(absPath);
 
-    if (realpath) {
-      return realpath.stats.isFile() ? realpath.abs : null;
+    if (realpath && realpath.stats.isFile()) {
+      return realpath.abs;
     }
 
     for (const ext of this.extensions) {


### PR DESCRIPTION
The current code fails in resolving the file `constants.ts` if the directory with the same name `constans` exists on the same level:

```bash
package/
  constants/
  index.ts
  constants.ts
```

```js
resolve('./constants', {
  basedir: "/Users/nodkz/services/core-services-common/src",
  conditions: ["require", "default", "browser"],
  extensions: [".ts", ".tsx", ".js", ".jsx", ".json", ".ejs"],
  moduleDirectory: ["node_modules"],
  paths: undefined,
  rootDir: "/Users/nodkz/services",
}); // returns null
```

This fix resolves this issue.